### PR TITLE
Replace loops with tensor operations

### DIFF
--- a/example_simple.py
+++ b/example_simple.py
@@ -28,7 +28,7 @@ ytest = outputs[idx[N:]]
 
 # Initialize the Gaussian process.
 lik = universalgp.lik.LikelihoodGaussian()
-cov = [universalgp.cov.SquaredExponential(1)]
+cov = universalgp.cov.SquaredExponential(1)
 
 # mean = universalgp.mean.ZeroOffset()
 inf = universalgp.inf.Variational(cov, lik)
@@ -47,4 +47,3 @@ plt.plot(xtrain, ytrain, '.', mew=2)
 plt.plot(xtest, ytest, 'o', mew=2)
 plt.plot(xtest, ypred, 'x', mew=2)
 plt.show()
-

--- a/universalgp/cov/cov_se.py
+++ b/universalgp/cov/cov_se.py
@@ -12,34 +12,52 @@ from .. import util
 
 
 class SquaredExponential:
-
-    def __init__(self, input_dim, length_scale=1.0, sf=1.0, iso_ard=False, white=0.01):
-
-        # if iso_ard = False, consider ARD (automatic relevance determination) kernel,
-        # else, consider ISO (isotropic ) kernel
-
-        if iso_ard:
-            self.length_scale = tf.Variable([length_scale], dtype=tf.float32)
-        else:
-            self.length_scale = tf.Variable(length_scale * tf.ones([input_dim]))
-
-        self.sf = tf.Variable([sf], dtype=tf.float32)
+    def __init__(self, input_dim, output_dim=1, length_scale=1.0, sf=1.0, iso_ard=False, white=0.01):
+        """
+        Args:
+            iso_ard: if iso_ard = False, consider ARD (automatic relevance determination) kernel, else, consider
+                ISO (isotropic) kernel
+        """
         self.input_dim = input_dim
-        self.white = white
+        self.num_latent = output_dim
+        self.white = tf.constant(white, dtype=tf.float32)
+        self.iso_ard = iso_ard
+        init_value = tf.constant_initializer(length_scale, dtype=tf.float32)
+        with tf.variable_scope("radial_basis_parameters"):
+            if iso_ard:
+                self.length_scale = tf.get_variable("length_scale", [output_dim, input_dim], initializer=init_value)
+            else:
+                self.length_scale = tf.get_variable("length_scale", [output_dim], initializer=init_value)
+            self.sf = tf.get_variable("sf", [output_dim], initializer=tf.constant_initializer(sf, dtype=tf.float32))
 
     def cov_func(self, point1, point2=None):
+        """
+        Args:
+            points1: Tensor(num_latent, num_inducing, input_dim) or Tensor(batch_size, input_dim)
+            points2: Tensor(batch_size, input_dim)
+        Returns:
+            Tensor of shape (num_latent, num_inducing, batch_size)
+        """
+        length_scale_br = tf.reshape(self.length_scale, [self.num_latent, 1, self.input_dim if self.iso_ard else 1])
         if point2 is None:
             point2 = point1
-            white_noise = self.white * tf.eye(tf.shape(point1)[0])
+            white_noise = self.white * tf.eye(tf.shape(point1)[-2])
         else:
             white_noise = 0.0
-        kern = (self.sf ** 2) * tf.exp(-util.sq_dist(
-            point1, point2) / 2.0 / (self.length_scale ** 2))
+        kern = self.sf[:, tf.newaxis, tf.newaxis]**2 * tf.exp(-util.sq_dist(point1, point2) / 2.0 / length_scale_br**2)
         return kern + white_noise
 
-    def diag_cov_func(self, point):
-        return (self.sf ** 2 + self.white) * tf.ones([tf.shape(point)[0]])
+    def diag_cov_func(self, points):
+        """
+        Args:
+            points: Tensor(batch_size, input_dim)
+        Returns:
+            Tensor of shape (num_latent, batch_size)
+        """
+        return (self.sf**2 + self.white)[:, tf.newaxis] * tf.ones([tf.shape(points)[-2]])
 
     def get_params(self):
         return [self.length_scale, self.sf]
 
+    def num_latent_functions(self):
+        return self.num_latent

--- a/universalgp/gp.py
+++ b/universalgp/gp.py
@@ -8,9 +8,6 @@ Created on Sun Jan 28 18:56:08 2018
 import numpy as np
 import tensorflow as tf
 
-from . import cov
-from . import mean
-from . import lik
 from . import inf
 from . import util
 
@@ -53,7 +50,7 @@ class GaussianProcess:
 
         # Initialize all model dimension constants.
         self.num_components = num_components
-        self.num_latent = len(self.cov)
+        self.num_latent = self.cov.num_latent_functions()
 
         # Repeat the inducing inputs for all latent processes if we haven't been given individually
         # specified inputs per process.
@@ -65,7 +62,7 @@ class GaussianProcess:
 
         self.raw_inducing_inputs = tf.Variable(inducing_inputs, dtype=tf.float32)
         self.raw_likelihood_params = self.lik.get_params()
-        self.raw_kernel_params = sum([k.get_params() for k in self.cov], [])
+        self.raw_kernel_params = self.cov.get_params()
 
         # Define placeholder variables for training and predicting.
         self.num_train = tf.placeholder(tf.float32, shape=[], name="num_train")
@@ -185,8 +182,8 @@ class GaussianProcess:
             num_batches = util.ceil_divide(test_inputs.shape[0], batch_size)
 
         test_inputs = np.array_split(test_inputs, num_batches)
-        pred_means = util.init_list(0.0, [num_batches])
-        pred_vars = util.init_list(0.0, [num_batches])
+        pred_means = [0.0] * num_batches
+        pred_vars = [0.0] * num_batches
 
         for i in range(num_batches):
             pred_means[i], pred_vars[i] = self.session.run(
@@ -198,47 +195,9 @@ class GaussianProcess:
         return np.concatenate(pred_means, axis=0), np.concatenate(pred_vars, axis=0)
 
     def _print_state(self, data, test, num_train, iter_num):
+        """Print the current state."""
         if num_train <= 100000:
             obj_func = self.session.run(self.obj_func, feed_dict={self.train_inputs: data.X,
                                                                   self.train_outputs: data.Y,
                                                                   self.num_train: num_train})
             print(f"iter={iter_num!r} [epoch={data.epochs_completed!r}] obj_func={obj_func!r}")
-
-    def _build_interim_vals(self, kernel_chol, inducing_inputs, train_inputs):
-        kern_prods = util.init_list(0.0, [self.num_latent])
-        kern_sums = util.init_list(0.0, [self.num_latent])
-        for i in range(self.num_latent):
-            ind_train_kern = self.cov[i].kernel(inducing_inputs[i, :, :], train_inputs)
-            # Compute A = Kxz.Kzz^(-1) = (Kzz^(-1).Kzx)^T.
-            kern_prods[i] = tf.transpose(tf.cholesky_solve(kernel_chol[i, :, :], ind_train_kern))
-            # We only need the diagonal components.
-            kern_sums[i] = (self.cov[i].diag_kernel(train_inputs) -
-                            util.diag_mul(kern_prods[i], ind_train_kern))
-
-        kern_prods = tf.stack(kern_prods, 0)
-        kern_sums = tf.stack(kern_sums, 0)
-        return kern_prods, kern_sums
-
-    def _build_samples(self, kern_prods, kern_sums, means, covars):
-        sample_means, sample_vars = self._build_sample_info(kern_prods, kern_sums, means, covars)
-        batch_size = tf.shape(sample_means)[0]
-        return (sample_means + tf.sqrt(sample_vars) *
-                tf.random_normal([self.num_samples, batch_size, self.num_latent]))
-
-    def _build_sample_info(self, kern_prods, kern_sums, means, covars):
-        sample_means = util.init_list(0.0, [self.num_latent])
-        sample_vars = util.init_list(0.0, [self.num_latent])
-        for i in range(self.num_latent):
-            if self.diag_post:
-                quad_form = util.diag_mul(kern_prods[i, :, :] * covars[i, :],
-                                          tf.transpose(kern_prods[i, :, :]))
-            else:
-                full_covar = covars[i, :, :] @ tf.transpose(covars[i, :, :])
-                quad_form = util.diag_mul(kern_prods[i, :, :] @ full_covar,
-                                          tf.transpose(kern_prods[i, :, :]))
-            sample_means[i] = kern_prods[i, :, :] @ means[i, :, tf.newaxis]
-            sample_vars[i] = (kern_sums[i, :] + quad_form)[:, tf.newaxis]
-
-        sample_means = tf.concat(sample_means, 1)
-        sample_vars = tf.concat(sample_vars, 1)
-        return sample_means, sample_vars

--- a/universalgp/lik/lik_Gaussian.py
+++ b/universalgp/lik/lik_Gaussian.py
@@ -11,7 +11,7 @@ import tensorflow as tf
 
 class LikelihoodGaussian:
     def __init__(self, sn=1.0):
-        self.sn = tf.Variable(sn)
+        self.sn = tf.get_variable("signal_noise", initializer=tf.constant(sn))
 
     def log_cond_prob(self, y, mu):
         var = self.sn ** 2

--- a/universalgp/util/__init__.py
+++ b/universalgp/util/__init__.py
@@ -15,6 +15,7 @@ from .util import ceil_divide
 from .util import get_flags
 from .util import log_cholesky_det
 from .util import diag_mul
-from .util import init_list
-from .util import logsumexp
 from .util import mat_square
+from .util import matmul_br
+from .util import cholesky_solve_br
+from .util import broadcast

--- a/universalgp/util/sq_dist.py
+++ b/universalgp/util/sq_dist.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Tue Jan 23 17:11:22 2018
 
@@ -7,16 +5,18 @@ Created on Tue Jan 23 17:11:22 2018
 """
 
 import tensorflow as tf
+from . import util
 
 MAX_DIST = 1e8
 
 
 def sq_dist(point1, point2):
-    square2 = tf.reduce_sum(point2 ** 2, 1)[:, tf.newaxis]
-    square1 = tf.reduce_sum(point1 ** 2, 1)[:, tf.newaxis]
-    distance = (square1 - 2 * point1 @ tf.transpose(point2) +
-                tf.transpose(square2))
+    """Compute the square distance between point1 and point2."""
+    square2 = tf.reduce_sum(point2 ** 2, -1, keep_dims=True)
+    square1 = tf.reduce_sum(point1 ** 2, -1, keep_dims=True)
+    distance = (square1 - 2 * util.matmul_br(point1, point2, transpose_b=True) + tf.matrix_transpose(square2))
+
+    # this ensures that exp(-distance) will never get too small
     distance = tf.clip_by_value(distance, 0.0, MAX_DIST)
 
     return distance
-

--- a/universalgp/util/util.py
+++ b/universalgp/util/util.py
@@ -1,30 +1,127 @@
-import copy
-
 import tensorflow as tf
+import numpy as np
 
 
-def init_list(init, dims):
-    def empty_list(dims):
-        if not dims:
-            return None
-        else:
-            return [copy.deepcopy(empty_list(dims[1:])) for i in range(dims[0])]
+def _merge_and_separate(a, b, func):
+    """
+    Helper function to make operations broadcast when they don't support it natively.
 
-    def fill_list(dims, l):
-        if len(dims) == 1:
-            for i in range(dims[0]):
-                if callable(init):
-                    l[i] = init()
-                else:
-                    l[i] = init
-        else:
-            for i in range(dims[0]):
-                fill_list(dims[1:], l[i])
+    The shape of `a` must be a subset of `b` in the sense that for example `b` has shape (j, k, l, m) and `a` has shape
+    (k, n, l) or (n, l) (for (j, k, n, l) you can just use the regular operation). Also supported is `b` with shape
+    (j, k, l) and `a` with shape (n, k).
 
-    l = empty_list(dims)
-    fill_list(dims, l)
+    Args:
+        a: Tensor
+        b: Tensor
+        func: a function that takes two arguments
+    Returns:
+        broadcasted result
+    """
+    a_rank = len(a.shape)
+    b_rank = len(b.shape)
+    if a_rank == b_rank:
+        # no need to broadcast; just apply the function
+        return func(a, b)
 
-    return l
+    b_sh = b.shape.as_list()
+    if b_rank == 3 and a_rank == 2:
+        perm_move_to_end = [1, 2, 0]
+        shape_merged = [-1, b_sh[2] * b_sh[0]]
+        shape_separated = [-1, b_sh[2], b_sh[0]]
+        perm_move_to_front = [2, 0, 1]
+    elif b_rank == 4 and a_rank == 2:
+        perm_move_to_end = [2, 3, 0, 1]
+        shape_merged = [-1, b_sh[3] * b_sh[0] * b_sh[1]]
+        shape_separated = [-1, b_sh[3], b_sh[0], b_sh[1]]
+        perm_move_to_front = [2, 3, 0, 1]
+    elif b_rank == 4 and a_rank == 3:
+        perm_move_to_end = [1, 2, 3, 0]
+        shape_merged = [b_sh[1], -1, b_sh[3] * b_sh[0]]
+        shape_separated = [b_sh[1], -1, b_sh[3], b_sh[0]]
+        perm_move_to_front = [3, 0, 1, 2]
+    else:
+        raise ValueError("Combination of ranks not supported")
+
+    # move the first dimension to the end and then merge it with the last dimension
+    b_merged = tf.reshape(tf.transpose(b, perm_move_to_end), shape_merged)
+    # apply function
+    result = func(a, b_merged)
+    # separate out the last dimension into what it was before the merging, then move the dimension from the back to the
+    # front again
+    return tf.transpose(tf.reshape(result, shape_separated), perm_move_to_front)
+
+
+def matmul_br(a, b, transpose_a=False, transpose_b=False):
+    """Broadcasting matmul.
+
+    Supported only up to 5 dimensional tensors.
+
+    Args:
+        a: Tensor
+        b: Tensor
+        transpose_a: whether or not to transpose a
+        transpose_b: whether or not to transpose b
+    Returns:
+        Broadcasted result of matrix multiplication.
+    """
+    a_dim = len(a.shape)
+    b_dim = len(b.shape)
+    # the output always has indices that are the tail of 'ijklm'
+    # the dimension to reduce is always 'x'
+    # the a indices always end in 'l'
+    # the b indices always end in 'm' and skip 'l'
+    # easy example when both are 3D and not transposing: 'klx,kxm->klm'
+    max_dim = max(a_dim, b_dim)
+    if max_dim > 5 or min(a_dim, b_dim) < 2:
+        raise ValueError("dimensions over 5 or under 2 are not supported")
+    # the index prefix is at most 'ijk' for 5 dimensional tensors and at the least '' (empty) for 2 dimensional tensors
+    a_index_prefix = 'ijk'[5-a_dim:]
+    b_index_prefix = 'ijk'[5-b_dim:]
+
+    # the last two dimensions are always there. they depend on whether the tensor is transposed or  not
+    a_index_suffix = 'xl' if transpose_a else 'lx'
+    b_index_suffix = 'mx' if transpose_b else 'xm'
+
+    out_indices = 'ijklm'[5-max_dim:]
+    return tf.einsum(a_index_prefix + a_index_suffix + ',' + b_index_prefix + b_index_suffix + '->' + out_indices, a, b)
+
+
+def cholesky_solve_br(chol, rhs):
+    """Broadcasting Cholesky solve.
+
+    This only works if `rhs` has higher rank.
+
+    Args:
+        chol: Cholesky factorization.
+        rhs: Right-hand side of equation to solve.
+    Returns:
+        Solution
+    """
+    return _merge_and_separate(chol, rhs, tf.cholesky_solve)
+
+
+def broadcast(tensor, tensor_with_target_shape):
+    """Make `tensor` have the same shape as `tensor_with_target_shape` by copying `tensor` over and over.
+
+    The rank of `tensor` has to be smaller than the rank of `tensor_with_target_shape`.
+    """
+    target_shape = tensor_with_target_shape.shape.as_list()
+    target_rank = len(target_shape)
+    input_shape = tensor.shape.as_list()
+    input_rank = len(input_shape)
+    if all(input_shape) and all(target_shape):
+        # the shapes are all fully specified. this means we can work with integers
+        # first we will pad the shape with 1s until the rank is the same. e.g. [m, n] -> [1, 1, 1, m, n]
+        expand_dims_shape = [1] * (target_rank - input_rank) + input_shape
+        # then we set the multiples that are necessary to reach the target shape. e.g. [j, k, l, 1, 1]
+        tile_multiples = target_shape[0:-input_rank] + [1] * input_rank
+    else:
+        # the shapes are not fully specified. we have to work with tensors
+        target_shape = tf.shape(tensor_with_target_shape)
+        expand_dims_shape = tf.concat([[1] * (target_rank - input_rank), tf.shape(tensor)], axis=0)
+        tile_multiples = tf.concat([target_shape[0:-input_rank], [1] * input_rank], axis=0)
+    input_with_expanded_dims = tf.reshape(tensor, expand_dims_shape)
+    return tf.tile(input_with_expanded_dims, tile_multiples)
 
 
 def ceil_divide(dividend, divisor):
@@ -32,23 +129,15 @@ def ceil_divide(dividend, divisor):
 
 
 def log_cholesky_det(chol):
-    return 2 * tf.reduce_sum(tf.log(tf.diag_part(chol)))
+    return 2 * tf.reduce_sum(tf.log(tf.matrix_diag_part(chol)), axis=-1)
 
 
 def diag_mul(mat1, mat2):
-    return tf.reduce_sum(mat1 * tf.transpose(mat2), 1)
-
-
-def logsumexp(vals, dim=None):
-    m = tf.reduce_max(vals, dim)
-    if dim is None:
-        return m + tf.log(tf.reduce_sum(tf.exp(vals - m), dim))
-    else:
-        return m + tf.log(tf.reduce_sum(tf.exp(vals - tf.expand_dims(m, dim)), dim))
+    return tf.reduce_sum(mat1 * tf.matrix_transpose(mat2), -1)
 
 
 def mat_square(mat):
-    return mat @ tf.transpose(mat)
+    return tf.matmul(mat, mat, transpose_b=True)
 
 
 def tri_vec_shape(N):


### PR DESCRIPTION
To achieve this, a lot of functions had to be changed so they work with
tensors that have more than 2 dimensions.

The changes mostly affected the functions in `inf_vi` that begin with
`_build`. But also the covariance and the likelihood had to be adapted.

One crucial component was a broadcasting `matmul` function. `tf.matmul`
does not broadcast which is a problem when you want to multiply two
tensors that don't have the same dimension. The current implementation
of a broadcasting `matmul` is based on `tf.einsum` which is a very
general tool for summing over certain dimensions in two tensors.