### PR TITLE
Restructure inference classes for eager execution

### DIFF
--- a/run_gp.py
+++ b/run_gp.py
@@ -5,6 +5,7 @@ This file is mainly for defining flags and choosing the right dataset.
 """
 import sys
 import tensorflow as tf
+import tensorflow.contrib.eager as tfe
 
 import datasets
 import universalgp
@@ -49,6 +50,7 @@ def main(_):
         train_func = universalgp.train_graph
     if FLAGS.tf_mode == 'eager':
         train_func = universalgp.train_eager
+        tfe.enable_eager_execution()  # enable Eager Execution (tensors are evaluated immediately, no sessions)
     else:
         ValueError('Unknown tf_mode: "{}"'.format(FLAGS.tf_mode))
     dataset = getattr(datasets, FLAGS.data)()

--- a/test/test_entropy.py
+++ b/test/test_entropy.py
@@ -2,6 +2,7 @@
 Test for computation of entropy
 """
 
+from collections import namedtuple
 import numpy as np
 import scipy.linalg as sl
 import scipy.special
@@ -45,9 +46,12 @@ def mat_square(mat):
 
 def construct_inf(input_dim, num_latents, num_components):
     """Construct a very basic inference object"""
+    vi_params = namedtuple('vi_params', ['num_components', 'diag_post', 'num_samples', 'optimize_inducing', 'use_loo'])
     lik = universalgp.lik.LikelihoodGaussian()
     cov = [universalgp.cov.SquaredExponential(input_dim) for _ in range(num_latents)]
-    return universalgp.inf.inf_vi.Variational(cov, lik, num_components=num_components)
+    return universalgp.inf.Variational(cov, lik, 1, 1,
+                                       vi_params(num_samples=10, num_components=num_components, diag_post=False,
+                                                 optimize_inducing=True, use_loo=False))
 
 
 def tf_constant(np_array):

--- a/test/test_inf_vi.py
+++ b/test/test_inf_vi.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import numpy as np
 import scipy.misc
 import scipy.stats
@@ -14,6 +15,7 @@ except ValueError:
 
 
 SIG_FIGS = 5
+PARAMS = namedtuple('vi_params', ['num_components', 'diag_post', 'num_samples', 'optimize_inducing', 'use_loo'])
 
 
 def build_entropy(inf, weights, means, covars):
@@ -55,7 +57,9 @@ def construct_simple_full():
     likelihood = lik.LikelihoodGaussian(1.0)
     kernel = [cov.SquaredExponential(input_dim=1, length_scale=1.0, sf=1.0)]
     # In most of our unit test, we will replace this value with something else.
-    return inference.Variational(num_samples=10, lik_func=likelihood, cov_func=kernel, num_components=1)
+    return inference.Variational(kernel, likelihood, 1, 1,
+                                 PARAMS(num_samples=10, num_components=1, diag_post=False, optimize_inducing=True,
+                                        use_loo=False))
 
 class TestSimpleFull:
     def test_simple_entropy(self):
@@ -169,7 +173,9 @@ class TestSimpleFull:
 def construct_simple_diag():
     likelihood = lik.LikelihoodGaussian(1.0)
     kernel = [cov.SquaredExponential(input_dim=1, length_scale=1.0, sf=1.0)]
-    return inference.Variational(num_samples=10, lik_func=likelihood, cov_func=kernel, num_components=1, diag_post=True)
+    return inference.Variational(kernel, likelihood, 1, 1,
+                                 PARAMS(num_samples=10, num_components=1, diag_post=True, optimize_inducing=True,
+                                        use_loo=False))
 
 
 class TestSimpleDiag:
@@ -247,7 +253,9 @@ class TestSimpleDiag:
 def construct_multi_full():
     likelihood = lik.LikelihoodSoftmax()
     kernels = [cov.SquaredExponential(input_dim=2, length_scale=1.0, sf=1.0) for _ in range(2)]
-    return inference.Variational(num_samples=10, lik_func=likelihood, cov_func=kernels, num_components=2)
+    return inference.Variational(kernels, likelihood, 1, 1,
+                                 PARAMS(num_samples=10, num_components=2, diag_post=False, optimize_inducing=True,
+                                        use_loo=False))
 
 
 class TestMultiFull:

--- a/universalgp/inf/inf_exact.py
+++ b/universalgp/inf/inf_exact.py
@@ -12,37 +12,38 @@ JITTER = 1e-2
 
 
 class Exact:
-    def __init__(self, cov_func, lik_func):
+    """Class for exact inference."""
+
+    def __init__(self, cov_func, lik_func, num_train, *_):
         self.cov = cov_func
         self.lik = lik_func
         self.sn = self.lik.get_params()[0]
+        with tf.variable_scope("exact_inference"):
+            self.train_inputs = tf.get_variable('train_inputs', [num_train, self.cov[0].input_dim], trainable=False)
+            self.train_outputs = tf.get_variable('train_outputs', [num_train, len(self.cov)], trainable=False)
 
-    def inference(self, train_inputs, train_outputs, test_inputs, *_):
+    def inference(self, train_inputs, train_outputs, is_train):
         """Build graph for computing predictive mean and variance and negative log marginal likelihood.
 
         Args:
             train_inputs: inputs
             train_outputs: targets
-            test_inputs: test inputs
+            is_train: whether we're training
         Returns:
-            negative log marginal likelihood and predictive mean and variance
+            negative log marginal likelihood
         """
+        if is_train:
+            # During training, we have to store the training data for computing the predictions later on
+            train_inputs = self.train_inputs.assign(train_inputs)
+            train_outputs = self.train_outputs.assign(train_outputs)
 
-        # kxx (num_train, num_train)
-        kxx = self.cov[0].cov_func(train_inputs) + self.sn ** 2 * tf.eye(tf.shape(train_inputs)[-2])
-
-        jitter = JITTER * tf.eye(tf.shape(train_inputs)[-2])
-        # chol (same size as kxx), add jitter has to be added
-        chol = tf.cholesky(kxx + jitter)
-        # alpha = chol.T \ (chol \ train_outputs)
-        alpha = tf.cholesky_solve(chol, train_outputs)
+        chol, alpha = self._build_interim_vals(train_inputs, train_outputs)
         # negative log marginal likelihood
         nlml = - self._build_log_marginal_likelihood(train_outputs, chol, alpha)
-        predictions = self._build_predict(train_inputs, test_inputs, chol, alpha)
 
-        return {'NLML': nlml}, predictions, []
+        return {'NLML': nlml}, []
 
-    def _build_predict(self, train_inputs, test_inputs, chol, alpha):
+    def predict(self, test_inputs):
         """Build graph for computing predictive mean and variance
 
         Args:
@@ -50,9 +51,10 @@ class Exact:
         Returns:
             predictive mean and variance
         """
+        chol, alpha = self._build_interim_vals(self.train_inputs, self.train_outputs)
 
         # kxx_star (num_latent, num_train, num_test)
-        kxx_star = self.cov[0].cov_func(train_inputs, test_inputs)
+        kxx_star = self.cov[0].cov_func(self.train_inputs, test_inputs)
         # f_star_mean (num_latent, num_test, 1)
         f_star_mean = tf.matmul(kxx_star, alpha, transpose_a=True)
         # Kx_star_x_star (num_latent, num_test)
@@ -65,6 +67,17 @@ class Exact:
         pred_means, pred_vars = self.lik.predict(tf.squeeze(f_star_mean, -1), var_f_star)
 
         return pred_means[:, tf.newaxis], pred_vars[:, tf.newaxis]
+
+    def _build_interim_vals(self, train_inputs, train_outputs):
+        # kxx (num_train, num_train)
+        kxx = self.cov[0].cov_func(train_inputs) + self.sn ** 2 * tf.eye(tf.shape(train_inputs)[-2])
+
+        jitter = JITTER * tf.eye(tf.shape(train_inputs)[-2])
+        # chol (same size as kxx), add jitter has to be added
+        chol = tf.cholesky(kxx + jitter)
+        # alpha = chol.T \ (chol \ train_outputs)
+        alpha = tf.cholesky_solve(chol, train_outputs)
+        return chol, alpha
 
     @staticmethod
     def _build_log_marginal_likelihood(train_outputs, chol, alpha):
@@ -79,3 +92,7 @@ class Exact:
         # sum over num_latent in the end to get a scalar, this corresponds to mutliplying the marginal likelihoods
         # of all the latent functions
         return tf.reduce_sum(log_marginal_likelihood)
+
+    def get_all_variables(self):
+        """Returns all variables, not just the ones that are trained."""
+        return [self.train_inputs, self.train_outputs]

--- a/universalgp/inf/inf_loo.py
+++ b/universalgp/inf/inf_loo.py
@@ -1,11 +1,5 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
-Created on Fri Feb  2 13:56:02 2018
-
-@author: zc223
-
-Usage: make leave-one-out inference for Gaussian process models
+Leave-one-out inference for Gaussian process models
 
 Reference:
 Carl Edward Rasmussen and Christopher K. I. Williams
@@ -21,30 +15,32 @@ JITTER = 1e-2
 
 
 class Loo:
-    def __init__(self, cov_func, lik_func):
+    """Class for inference based on LOO."""
+
+    def __init__(self, cov_func, lik_func, num_train, *_):
         self.cov = cov_func
         self.lik = lik_func
         self.sn = self.lik.get_params()[0]
+        with tf.variable_scope("loo_inference"):
+            self.train_inputs = tf.get_variable('train_inputs', [num_train, self.cov[0].input_dim], trainable=False)
+            self.train_outputs = tf.get_variable('train_outputs', [num_train, len(self.cov)], trainable=False)
 
-    def inference(self, train_inputs, train_outputs, test_inputs, *_):
+    def inference(self, train_inputs, train_outputs, is_train):
         """Build graph for computing predictive mean and variance and negative log probability.
 
         Args:
             train_inputs: inputs
             train_outputs: targets
-            test_inputs: test inputs
+            is_train: whether we're training
         Returns:
-            negative log probability and predictive mean and variance
+            negative log marginal likelihood
         """
+        if is_train:
+            # During training, we have to store the training data for computing the predictions later on
+            train_inputs = self.train_inputs.assign(train_inputs)
+            train_outputs = self.train_outputs.assign(train_outputs)
 
-        # kxx (num_train, num_train)
-        kxx = self.cov[0].cov_func(train_inputs) + self.sn ** 2 * tf.eye(tf.shape(train_inputs)[-2])
-
-        jitter = JITTER * tf.eye(tf.shape(train_inputs)[-2])
-        # chol (same size as kxx), add jitter has to be added
-        chol = tf.cholesky(kxx + jitter)
-        # alpha = chol.T \ (chol \ train_outputs)
-        alpha = tf.cholesky_solve(chol, train_outputs)
+        chol, alpha = self._build_interim_vals(train_inputs, train_outputs)
         # precision = inv(kxx)
         precision = tf.cholesky_solve(chol, tf.eye(tf.shape(train_inputs)[-2]))
         precision_diag = tf.matrix_diag_part(precision)
@@ -54,11 +50,10 @@ class Loo:
 
         # negative log probability (nlp), also called log pseudo-likelihood)
         nlp = - self._build_loo(train_outputs, loo_fmu, loo_fs2)
-        predictions = self._build_predict(train_inputs, test_inputs, chol, alpha)
 
-        return {'NLP': nlp}, predictions, []
+        return {'NLP': nlp}, []
 
-    def _build_predict(self, train_inputs, test_inputs, chol, alpha):
+    def predict(self, test_inputs):
         """Build graph for computing predictive mean and variance
 
         Args:
@@ -66,8 +61,10 @@ class Loo:
         Returns:
             predictive mean and variance
         """
+        chol, alpha = self._build_interim_vals(self.train_inputs, self.train_outputs)
+
         # kxx_star (num_latent, num_train, num_test)
-        kxx_star = self.cov[0].cov_func(train_inputs, test_inputs)
+        kxx_star = self.cov[0].cov_func(self.train_inputs, test_inputs)
         # f_star_mean (num_latent, num_test, 1)
         f_star_mean = tf.matmul(kxx_star, alpha, transpose_a=True)
         # Kx_star_x_star (num_latent, num_test)
@@ -81,7 +78,22 @@ class Loo:
 
         return pred_means, pred_vars
 
+    def _build_interim_vals(self, train_inputs, train_outputs):
+        # kxx (num_train, num_train)
+        kxx = self.cov[0].cov_func(train_inputs) + self.sn ** 2 * tf.eye(tf.shape(train_inputs)[-2])
+
+        jitter = JITTER * tf.eye(tf.shape(train_inputs)[-2])
+        # chol (same size as kxx), add jitter has to be added
+        chol = tf.cholesky(kxx + jitter)
+        # alpha = chol.T \ (chol \ train_outputs)
+        alpha = tf.cholesky_solve(chol, train_outputs)
+        return chol, alpha
+
     def _build_loo(self, train_outputs, loo_fmu, loo_fs2):
         pred_log_probability = self.lik.pred_log_prob(train_outputs, loo_fmu, loo_fs2)
 
         return tf.reduce_sum(pred_log_probability)
+
+    def get_all_variables(self):
+        """Returns all variables, not just the ones that are trained."""
+        return [self.train_inputs, self.train_outputs]


### PR DESCRIPTION
The main goal of this change is to be able to use exact inference in eager
execution. Another goal is to separate inference from prediction because
the code in the training loops was a bit hacky when both are done in the
same function.

Major changes:

* separate `predict` and `inference`
* move variable definition code out of `inference()` and into
`__init__()`
* reduce the number of parameters for the init function of
`inf.Variational` by putting extra parameters into a `params` structure
* get rid of `EeagerVariableStore`

I hope this will be the last big structural change.