### PR TITLE
Extend the flag system to likelihood and kernel

### DIFF
--- a/gaussian_process.py
+++ b/gaussian_process.py
@@ -20,8 +20,6 @@ tf.app.flags.DEFINE_string('inf', 'Variational', 'Inference method')
 # tf.app.flags.DEFINE_string('inf', 'Exact', 'Inference method')
 tf.app.flags.DEFINE_string('cov', 'SquaredExponential', 'Covariance function')
 tf.app.flags.DEFINE_float('lr', 0.005, 'Learning rate')
-tf.app.flags.DEFINE_boolean('use_ard', True, 'Whether to use an automatic relevance determination kernel')
-tf.app.flags.DEFINE_float('length_scale', 1.0, 'Initial lenght scale for the kernel')
 tf.app.flags.DEFINE_integer('loo_steps', None, 'Number of steps for optimizing LOO loss')
 ### Tensorflow flags
 tf.app.flags.DEFINE_string('model_name', 'local', 'Name of model (used for name of checkpoints)')

--- a/scripts/save_predictions.py
+++ b/scripts/save_predictions.py
@@ -34,10 +34,10 @@ def main():
     # load GP model from checkpoint
     with tfe.restore_variables_on_create(CHECKPOINT_PATH):
         gp = inf.Variational([cov.SquaredExponential(INPUT_DIM) for _ in range(OUTPUT_DIM)],
-                             LIKELIHODD(),
+                             LIKELIHODD({'num_samples_pred': NUM_SAMPLES}),
                              NUM_TRAIN,
                              NUM_INDUCING,
-                             {'num_components': NUM_COMPONENTS, 'num_samples': NUM_SAMPLES, 'diag_post': DIAG_POST})
+                             {'num_components': NUM_COMPONENTS, 'diag_post': DIAG_POST})
 
     # pred_means, pred_vars = gp.predict([[1., 1.]])
     # print(pred_means)

--- a/scripts/save_predictions.py
+++ b/scripts/save_predictions.py
@@ -15,6 +15,7 @@ NUM_INDUCING = 300
 NUM_COMPONENTS = 1
 NUM_SAMPLES = 1000
 DIAG_POST = False
+ISO = False
 LIKELIHODD = lik.LikelihoodLogistic
 RESULT_PATH = "./predictions.npz"
 
@@ -33,7 +34,7 @@ def main():
     """
     # load GP model from checkpoint
     with tfe.restore_variables_on_create(CHECKPOINT_PATH):
-        gp = inf.Variational([cov.SquaredExponential(INPUT_DIM) for _ in range(OUTPUT_DIM)],
+        gp = inf.Variational([cov.SquaredExponential(INPUT_DIM, {'iso': ISO}) for _ in range(OUTPUT_DIM)],
                              LIKELIHODD({'num_samples_pred': NUM_SAMPLES}),
                              NUM_TRAIN,
                              NUM_INDUCING,

--- a/test/test_entropy.py
+++ b/test/test_entropy.py
@@ -45,7 +45,7 @@ def mat_square(mat):
 
 def construct_inf(input_dim, num_latents, num_components):
     """Construct a very basic inference object"""
-    lik = universalgp.lik.LikelihoodGaussian()
+    lik = universalgp.lik.LikelihoodGaussian({'sn': 1.0})
     cov = [universalgp.cov.SquaredExponential(input_dim) for _ in range(num_latents)]
     return universalgp.inf.Variational(cov, lik, 1, 1, {'num_components': num_components, 'optimize_inducing': True,
                                                         'num_samples': 10, 'diag_post': False, 'use_loo': False})

--- a/test/test_entropy.py
+++ b/test/test_entropy.py
@@ -46,7 +46,8 @@ def mat_square(mat):
 def construct_inf(input_dim, num_latents, num_components):
     """Construct a very basic inference object"""
     lik = universalgp.lik.LikelihoodGaussian({'sn': 1.0})
-    cov = [universalgp.cov.SquaredExponential(input_dim) for _ in range(num_latents)]
+    cov = [universalgp.cov.SquaredExponential(input_dim, dict(iso=False, length_scale=1., sf=1.))
+           for _ in range(num_latents)]
     return universalgp.inf.Variational(cov, lik, 1, 1, {'num_components': num_components, 'optimize_inducing': True,
                                                         'num_samples': 10, 'diag_post': False, 'use_loo': False})
 

--- a/test/test_inf_vi.py
+++ b/test/test_inf_vi.py
@@ -54,7 +54,7 @@ def build_sample_info(inf, kern_prods, kern_sums, means, covars):
 
 def construct_simple_full():
     likelihood = lik.LikelihoodGaussian({'sn': 1.0})
-    kernel = [cov.SquaredExponential(input_dim=1, length_scale=1.0, sf=1.0)]
+    kernel = [cov.SquaredExponential(input_dim=1, args=dict(length_scale=1.0, sf=1.0, iso=False))]
     # In most of our unit test, we will replace this value with something else.
     return inference.Variational(kernel, likelihood, 1, 1, PARAMS)
 
@@ -169,7 +169,7 @@ class TestSimpleFull:
 
 def construct_simple_diag():
     likelihood = lik.LikelihoodGaussian({'sn': 1.0})
-    kernel = [cov.SquaredExponential(input_dim=1, length_scale=1.0, sf=1.0)]
+    kernel = [cov.SquaredExponential(input_dim=1, args=dict(length_scale=1.0, sf=1.0, iso=False))]
     return inference.Variational(kernel, likelihood, 1, 1, {**PARAMS, 'diag_post': True})
 
 
@@ -247,7 +247,7 @@ class TestSimpleDiag:
 
 def construct_multi_full():
     likelihood = lik.LikelihoodSoftmax({'num_samples_pred': 100})
-    kernels = [cov.SquaredExponential(input_dim=2, length_scale=1.0, sf=1.0) for _ in range(2)]
+    kernels = [cov.SquaredExponential(input_dim=2, args=dict(length_scale=1.0, sf=1.0, iso=False)) for _ in range(2)]
     return inference.Variational(kernels, likelihood, 1, 1, {**PARAMS, 'num_components': 2})
 
 

--- a/test/test_inf_vi.py
+++ b/test/test_inf_vi.py
@@ -53,7 +53,7 @@ def build_sample_info(inf, kern_prods, kern_sums, means, covars):
 ###########################
 
 def construct_simple_full():
-    likelihood = lik.LikelihoodGaussian(1.0)
+    likelihood = lik.LikelihoodGaussian({'sn': 1.0})
     kernel = [cov.SquaredExponential(input_dim=1, length_scale=1.0, sf=1.0)]
     # In most of our unit test, we will replace this value with something else.
     return inference.Variational(kernel, likelihood, 1, 1, PARAMS)
@@ -168,7 +168,7 @@ class TestSimpleFull:
 ###########################
 
 def construct_simple_diag():
-    likelihood = lik.LikelihoodGaussian(1.0)
+    likelihood = lik.LikelihoodGaussian({'sn': 1.0})
     kernel = [cov.SquaredExponential(input_dim=1, length_scale=1.0, sf=1.0)]
     return inference.Variational(kernel, likelihood, 1, 1, {**PARAMS, 'diag_post': True})
 
@@ -246,7 +246,7 @@ class TestSimpleDiag:
 ###########################
 
 def construct_multi_full():
-    likelihood = lik.LikelihoodSoftmax()
+    likelihood = lik.LikelihoodSoftmax({'num_samples_pred': 100})
     kernels = [cov.SquaredExponential(input_dim=2, length_scale=1.0, sf=1.0) for _ in range(2)]
     return inference.Variational(kernels, likelihood, 1, 1, {**PARAMS, 'num_components': 2})
 

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -26,7 +26,7 @@ def construct_input():
 def test_variational_complete():
     # construct objects
     train_inputs, train_outputs, test_inputs, num_train, inducing_inputs = construct_input()
-    likelihood = lik.LikelihoodGaussian(1.0)
+    likelihood = lik.LikelihoodGaussian({'sn': 1.0})
     kernel = [cov.SquaredExponential(input_dim=1, length_scale=0.5, sf=1.0)]
     vi = inference.Variational(kernel, likelihood, num_train, inducing_inputs,
                                {'num_samples': 5000000, 'num_components': 1, 'optimize_inducing': False,
@@ -48,7 +48,7 @@ def test_variational_complete():
 def test_exact_complete():
     # construct objects
     train_inputs, train_outputs, test_inputs, num_train, _ = construct_input()
-    likelihood = lik.LikelihoodGaussian(1.0)
+    likelihood = lik.LikelihoodGaussian({'sn': 1.0})
     kernel = [cov.SquaredExponential(input_dim=1, length_scale=0.5, sf=1.0)]
     exact = inference.Exact(kernel, likelihood, num_train)
 

--- a/test/test_inference.py
+++ b/test/test_inference.py
@@ -27,7 +27,7 @@ def test_variational_complete():
     # construct objects
     train_inputs, train_outputs, test_inputs, num_train, inducing_inputs = construct_input()
     likelihood = lik.LikelihoodGaussian({'sn': 1.0})
-    kernel = [cov.SquaredExponential(input_dim=1, length_scale=0.5, sf=1.0)]
+    kernel = [cov.SquaredExponential(input_dim=1, args=dict(length_scale=0.5, sf=1.0, iso=False))]
     vi = inference.Variational(kernel, likelihood, num_train, inducing_inputs,
                                {'num_samples': 5000000, 'num_components': 1, 'optimize_inducing': False,
                                 'use_loo': True, 'diag_post': False})
@@ -49,7 +49,7 @@ def test_exact_complete():
     # construct objects
     train_inputs, train_outputs, test_inputs, num_train, _ = construct_input()
     likelihood = lik.LikelihoodGaussian({'sn': 1.0})
-    kernel = [cov.SquaredExponential(input_dim=1, length_scale=0.5, sf=1.0)]
+    kernel = [cov.SquaredExponential(input_dim=1, args=dict(length_scale=0.5, sf=1.0, iso=False))]
     exact = inference.Exact(kernel, likelihood, num_train)
 
     # compute losses and predictions

--- a/universalgp/cov/cov_se.py
+++ b/universalgp/cov/cov_se.py
@@ -10,26 +10,28 @@ import numpy as np
 import tensorflow as tf
 from .. import util
 
+tf.app.flags.DEFINE_float('length_scale', 1.0, 'Initial length scale for the kernel')
+tf.app.flags.DEFINE_float('sf', 1.0, 'Initial standard dev for the kernel')
+tf.app.flags.DEFINE_boolean('iso', False, 'Whether to use an isotropic kernel otherwise use automatic relevance det')
+
 
 class SquaredExponential:
-    def __init__(self, input_dim, length_scale=1.0, sf=1.0, iso=False, name=None):
+    """Squared exponential kernel"""
+    def __init__(self, input_dim, args, name=None):
         """
         Args:
-            iso:
-        if iso:
-             consider ISO (isotropic) kernel
-        else:
-             consider ARD (automatic relevance determination) kernel
+            input_dim: the number of input dimensions
         """
         self.input_dim = input_dim
-        self.iso = iso
-        init_value = tf.constant_initializer(length_scale, dtype=tf.float32)
+        self.iso = args['iso']
+        init_len = tf.constant_initializer(args['length_scale'], dtype=tf.float32) if 'length_scale' in args else None
+        init_sf = tf.constant_initializer(args['sf'], dtype=tf.float32) if 'sf' in args else None
         with tf.variable_scope(name, "cov_se_parameters"):
-            if not iso:
-                self.length_scale = tf.get_variable("length_scale", [input_dim], initializer=init_value)
+            if not args['iso']:
+                self.length_scale = tf.get_variable("length_scale", [input_dim], initializer=init_len)
             else:
-                self.length_scale = tf.get_variable("length_scale", shape=[], initializer=init_value)
-            self.sf = tf.get_variable("sf", shape=[], initializer=tf.constant_initializer(sf, dtype=tf.float32))
+                self.length_scale = tf.get_variable("length_scale", shape=[], initializer=init_len)
+            self.sf = tf.get_variable("sf", shape=[], initializer=init_sf)
 
     def cov_func(self, point1, point2=None):
         """

--- a/universalgp/lik/lik_gaussian.py
+++ b/universalgp/lik/lik_gaussian.py
@@ -8,10 +8,13 @@ Created on Sun Jan 28 18:56:08 2018
 import numpy as np
 import tensorflow as tf
 
+tf.app.flags.DEFINE_float('sn', 1.0, 'Initial standard dev for the Gaussian likelihood')
+
 
 class LikelihoodGaussian:
-    def __init__(self, sn=1.0):
-        self.sn = tf.get_variable("Likelihood_param", initializer=tf.constant(sn))
+    def __init__(self, args):
+        init_sn = tf.constant_initializer(args['sn'], dtype=tf.float32) if 'sn' in args else None
+        self.sn = tf.get_variable("Likelihood_param", [], initializer=init_sn)
 
     def log_cond_prob(self, y, mu):
         var = self.sn ** 2

--- a/universalgp/lik/lik_logistic.py
+++ b/universalgp/lik/lik_logistic.py
@@ -4,8 +4,8 @@ from universalgp import util
 
 
 class LikelihoodLogistic:
-    def __init__(self, num_samples=2000):
-        self.num_samples = num_samples
+    def __init__(self, args):
+        self.num_samples = args['num_samples_pred']
 
     def log_cond_prob(self, outputs, latent):
         # return latent * (outputs - 1) - tf.log(1 + tf.exp(-latent))

--- a/universalgp/lik/lik_softmax.py
+++ b/universalgp/lik/lik_softmax.py
@@ -2,10 +2,13 @@ import tensorflow as tf
 
 from universalgp import util
 
+tf.app.flags.DEFINE_integer('num_samples_pred', 2000, 'Number of samples for mean and variance estimate for prediction')
+
 
 class LikelihoodSoftmax:
-    def __init__(self, num_samples=2000):
-        self.num_samples = num_samples
+    """Softmax likelihood used for multi-class classification"""
+    def __init__(self, args):
+        self.num_samples = args['num_samples_pred']
 
     def log_cond_prob(self, outputs, latent):
         # shape of `outputs`: (batch_size, output_dim)

--- a/universalgp/train_eager.py
+++ b/universalgp/train_eager.py
@@ -41,8 +41,7 @@ def train_gp(dataset, args):
     # Restore from existing checkpoint
     with tfe.restore_variables_on_create(tf.train.latest_checkpoint(out_dir)):
         # Gather parameters
-        cov_func = [getattr(cov, args['cov'])(dataset.input_dim, args['length_scale'], iso=not args['use_ard'])
-                    for _ in range(dataset.output_dim)]
+        cov_func = [getattr(cov, args['cov'])(dataset.input_dim, args) for _ in range(dataset.output_dim)]
         lik_func = getattr(lik, dataset.lik)(args)
         hyper_params = lik_func.get_params() + sum([k.get_params() for k in cov_func], [])
 
@@ -175,8 +174,7 @@ def predict(test_inputs, saved_model, dataset_info, args):
 
     with tfe.restore_variables_on_create(saved_model):
         # Creating the inference object here will restore the variables from the saved model
-        cov_func = [getattr(cov, args['cov'])(test_inputs.shape[1], iso=not args['use_ard'])
-                    for _ in range(dataset_info.output_dim)]
+        cov_func = [getattr(cov, args['cov'])(test_inputs.shape[1], args) for _ in range(dataset_info.output_dim)]
         lik_func = getattr(lik, dataset_info.lik)(args)
         gp = getattr(inf, args['inf'])(cov_func, lik_func, dataset_info.num_train, num_inducing, args)
 

--- a/universalgp/train_eager.py
+++ b/universalgp/train_eager.py
@@ -43,7 +43,7 @@ def train_gp(dataset, args):
         # Gather parameters
         cov_func = [getattr(cov, args['cov'])(dataset.input_dim, args['length_scale'], iso=not args['use_ard'])
                     for _ in range(dataset.output_dim)]
-        lik_func = getattr(lik, dataset.lik)()
+        lik_func = getattr(lik, dataset.lik)(args)
         hyper_params = lik_func.get_params() + sum([k.get_params() for k in cov_func], [])
 
         gp = getattr(inf, args['inf'])(cov_func, lik_func, dataset.num_train, dataset.inducing_inputs, args)
@@ -177,7 +177,7 @@ def predict(test_inputs, saved_model, dataset_info, args):
         # Creating the inference object here will restore the variables from the saved model
         cov_func = [getattr(cov, args['cov'])(test_inputs.shape[1], iso=not args['use_ard'])
                     for _ in range(dataset_info.output_dim)]
-        lik_func = getattr(lik, dataset_info.lik)()
+        lik_func = getattr(lik, dataset_info.lik)(args)
         gp = getattr(inf, args['inf'])(cov_func, lik_func, dataset_info.num_train, num_inducing, args)
 
     test_inputs = np.array_split(test_inputs, num_batches)

--- a/universalgp/train_graph.py
+++ b/universalgp/train_graph.py
@@ -26,8 +26,7 @@ def build_gaussian_process(features, labels, mode, params: dict):
     inputs = tf.feature_column.input_layer(features, params['feature_columns'])
 
     # Gather parameters
-    cov_func = [getattr(cov, params['cov'])(params['input_dim'], params['length_scale'], iso=not params['use_ard'])
-                for _ in range(params['output_dim'])]
+    cov_func = [getattr(cov, params['cov'])(params['input_dim'], params) for _ in range(params['output_dim'])]
     lik_func = getattr(lik, params['lik'])(params)
     if mode == tf.estimator.ModeKeys.TRAIN:
         inducing_param = params['inducing_inputs']

--- a/universalgp/train_graph.py
+++ b/universalgp/train_graph.py
@@ -28,7 +28,7 @@ def build_gaussian_process(features, labels, mode, params: dict):
     # Gather parameters
     cov_func = [getattr(cov, params['cov'])(params['input_dim'], params['length_scale'], iso=not params['use_ard'])
                 for _ in range(params['output_dim'])]
-    lik_func = getattr(lik, params['lik'])()
+    lik_func = getattr(lik, params['lik'])(params)
     if mode == tf.estimator.ModeKeys.TRAIN:
         inducing_param = params['inducing_inputs']
     else:  # when we're not training, we only need the shape of the inducing inputs


### PR DESCRIPTION
The general idea is always that the flags are defined in the file where they are used. Then all classes and functions that need a flag value get the `args` parameter which usually contains all flags. The class or function then picks the flags it needs from `args`.