### PR TITLE
Offer to save predictions instead of variables

### DIFF
--- a/gaussian_process.py
+++ b/gaussian_process.py
@@ -33,7 +33,7 @@ tf.app.flags.DEFINE_string('save_dir', None,  # '/its/home/tk324/tensorflow/',
 tf.app.flags.DEFINE_string('plot', None, 'Which function to use for plotting (or None)')
 tf.app.flags.DEFINE_integer('logging_steps', 1, 'How many steps between logging the loss')
 tf.app.flags.DEFINE_string('gpus', '0', 'Which GPUs to use (should normally only be one)')
-tf.app.flags.DEFINE_boolean('save_vars', False, 'Whether to save the trained variables as numpy arrays in the end')
+tf.app.flags.DEFINE_boolean('save_preds', False, 'Whether to save the predictions for the test data')
 
 
 def main(_):

--- a/universalgp/train_graph.py
+++ b/universalgp/train_graph.py
@@ -107,12 +107,8 @@ def train_gp(data, args):
 
     tf.estimator.train_and_evaluate(gp, trainer, evaluator)  # this can be replaced by a loop that calls gp.train()
 
-    if args['save_vars'] and args['save_dir'] is not None:
-        print("Saving variables...")
-        var_collection = {name: gp.get_variable_value(name) for name in gp.get_variable_names()}
-        np.savez_compressed(Path(args['save_dir']) / Path(args['model_name']) / Path("vars"), **var_collection)
-    if args['plot'] is not None:
-        # Create predictions
+    if args['plot'] or (args['save_preds'] and args['save_dir']):
+        print("Making predictions...")
         predictions_gen = gp.predict(input_fn=lambda: data.test_fn().batch(len(data.xtest)))
         pred_mean = []
         pred_var = []
@@ -121,5 +117,9 @@ def train_gp(data, args):
             pred_var.append(prediction['var'])
         pred_mean = np.stack(pred_mean)
         pred_var = np.stack(pred_var)
+    if args['save_preds'] and args['save_dir']:
+        np.savez_compressed(Path(args['save_dir']) / Path(args['model_name']) / Path("predictions"),
+                            pred_mean=pred_mean, pred_var=pred_var)
+    if args['plot']:
         getattr(util.plot, args['plot'])(pred_mean, pred_var, data)
     return gp


### PR DESCRIPTION
This adds a flag to save the predictions to a file after training is complete.

Previously there was a flag to save the variables to a file after training is
complete. This feature was removed.

The values of the variables are easy to get from the saved model. The
predictions can actually be not so easy to get if the model is very
computationally expensive.

The predictions are stored as numpy files. It would have been very
tedious to save them as text files because then you have to indicate
somehow which column represents what.