### PR TITLE
Flags in datasets and improve `select_training_and_test`

### DIFF
--- a/datasets/definition.py
+++ b/datasets/definition.py
@@ -30,33 +30,26 @@ class Dataset(NamedTuple):
     strain: np.ndarray = None  # sensitive attribute for train
 
 
-def select_training_and_test(num_train, inputs, outputs, sensitive_attr=None):
+def select_training_and_test(num_train, *data_parts):
     """Randomly devide a dataset into training and test
-
     Args:
-        num_train: desired number of examples in training set
-        inputs: inputs of the dataset
-        outputs: outputs of the dataset
-        sensitive_attr: (optional) sensitive attributes
+        num_train: Desired number of examples in training set
+        *data_parts: Parts of the dataset. The * means that the function can take an arbitrary number of arguments.
     Returns:
-        train input, train output, test input, test output
+        Two lists: data_parts_train, data_parts_test
     """
-    idx = np.arange(inputs.shape[0])
+    idx = np.arange(data_parts[0].shape[0])
     np.random.shuffle(idx)
     train_idx = idx[:num_train]
     test_idx = np.sort(idx[num_train:])
 
-    xtrain = inputs[train_idx]
-    ytrain = outputs[train_idx]
-    xtest = inputs[test_idx]
-    ytest = outputs[test_idx]
+    data_parts_train = []
+    data_parts_test = []
+    for data_part in data_parts:  # data_parts is a list of the arguments passed to the function
+        data_parts_train.append(data_part[train_idx])
+        data_parts_test.append(data_part[test_idx])
 
-    if sensitive_attr is not None:
-        strain = sensitive_attr[train_idx]
-        stest = sensitive_attr[test_idx]
-        return xtrain, ytrain, xtest, ytest, strain, stest
-
-    return xtrain, ytrain, xtest, ytest
+    return data_parts_train, data_parts_test
 
 
 def to_tf_dataset_fn(inputs: np.ndarray, outputs: np.ndarray, sensitive=None, dtype_in=tf.float32, dtype_out=tf.float32,

--- a/datasets/maize.py
+++ b/datasets/maize.py
@@ -9,7 +9,7 @@ from .definition import Dataset, to_tf_dataset_fn
 DATA_PATH = Path("datasets") / Path("data") / Path("Maize Yield150318.csv")
 
 
-def maize_yield():
+def maize_yield(_):
     """Maize dataset"""
     data = np.loadtxt(DATA_PATH, delimiter=',', skiprows=1).astype(np.float32)
     x = data[:, 1:]

--- a/datasets/maize.py
+++ b/datasets/maize.py
@@ -1,6 +1,5 @@
 """Maize dataset"""
 from pathlib import Path
-import tensorflow as tf
 import numpy as np
 from scipy.stats import zscore
 

--- a/datasets/mnist.py
+++ b/datasets/mnist.py
@@ -1,8 +1,6 @@
 """
 MNIST dataset
 """
-
-import tensorflow as tf
 from tensorflow.examples.tutorials.mnist import input_data
 
 import sklearn.cluster

--- a/datasets/mnist.py
+++ b/datasets/mnist.py
@@ -22,7 +22,7 @@ def _init_z(train_inputs, num_inducing):
     return inducing_locations
 
 
-def mnist():
+def mnist(_):
     """MNIST dataset with one hot labels"""
     data = input_data.read_data_sets('./datasets/data/', one_hot=True)
 

--- a/datasets/sensitive.py
+++ b/datasets/sensitive.py
@@ -22,7 +22,7 @@ def sensitive_example():
     inputs, outputs, sensi_attr = _generate_feature(n_all, disc_factor)
 
     num_train = 200
-    xtrain, ytrain, xtest, ytest, sensi_attr_train, sensi_attr_test = select_training_and_test(
+    (xtrain, ytrain, sensi_attr_train), (xtest, ytest, sensi_attr_test) = select_training_and_test(
         2 * num_train, inputs, outputs[..., np.newaxis], sensi_attr)
     num_inducing = 200
 

--- a/datasets/sensitive.py
+++ b/datasets/sensitive.py
@@ -12,7 +12,7 @@ from scipy.stats import multivariate_normal
 from .definition import Dataset, select_training_and_test, to_tf_dataset_fn
 
 
-def sensitive_example():
+def sensitive_example(_):
     """Synthetic data with bias"""
     SEED = 123
     np.random.seed(SEED)  # set the random seed, which can be reproduced again

--- a/datasets/sensitive.py
+++ b/datasets/sensitive.py
@@ -4,17 +4,16 @@ A sensitive feature, 0.0 : protected group (e.g., female)
                      1.0 : non-protected group (e.g., male).
 For parity demographic
 """
-
 import numpy as np
-import tensorflow as tf
 from scipy.stats import multivariate_normal
 
 from .definition import Dataset, select_training_and_test, to_tf_dataset_fn
 
+SEED = 123
+
 
 def sensitive_example(_):
     """Synthetic data with bias"""
-    SEED = 123
     np.random.seed(SEED)  # set the random seed, which can be reproduced again
 
     n_all = 250

--- a/datasets/sensitive_odds.py
+++ b/datasets/sensitive_odds.py
@@ -21,7 +21,7 @@ def sensitive_odds_example():
     inputs, outputs, sensi_attr = _generate_feature(n_all)
 
     num_train = 200
-    xtrain, ytrain, xtest, ytest, sensi_attr_train, sensi_attr_test = select_training_and_test(
+    (xtrain, ytrain, sensi_attr_train), (xtest, ytest, sensi_attr_test) = select_training_and_test(
         4 * num_train, inputs, outputs[..., np.newaxis], sensi_attr)
     num_inducing = 200
 

--- a/datasets/sensitive_odds.py
+++ b/datasets/sensitive_odds.py
@@ -12,7 +12,7 @@ from scipy.stats import multivariate_normal
 from .definition import Dataset, to_tf_dataset_fn, select_training_and_test
 
 
-def sensitive_odds_example():
+def sensitive_odds_example(_):
     """Simple equality odds example with synthetic data."""
     SEED = 2345657
     np.random.seed(SEED)  # set the random seed, which can be reproduced again

--- a/datasets/sensitive_odds.py
+++ b/datasets/sensitive_odds.py
@@ -4,17 +4,16 @@ Usage: Generate the simple synthetic data with two non-sensitive features and on
                             1.0 : non-protected group (e.g., male).
        For equality odds fairness
 """
-
 import numpy as np
-import tensorflow as tf
 from scipy.stats import multivariate_normal
 
 from .definition import Dataset, to_tf_dataset_fn, select_training_and_test
 
+SEED = 2345657
+
 
 def sensitive_odds_example(_):
     """Simple equality odds example with synthetic data."""
-    SEED = 2345657
     np.random.seed(SEED)  # set the random seed, which can be reproduced again
 
     n_all = 250

--- a/datasets/sensitive_zhang.py
+++ b/datasets/sensitive_zhang.py
@@ -1,8 +1,10 @@
+"""Synthetic dataset with bias"""
 import numpy as np
 from numpy import random
-import tensorflow as tf
 
 from .definition import Dataset, select_training_and_test, to_tf_dataset_fn
+
+SEED = 1234
 
 
 def sensitive_zhang(flags):
@@ -18,6 +20,7 @@ def sensitive_zhang(flags):
     raw_output_std = .5  # standard dev of the raw output with respect to latent var. smaller -> easier to predict
 
     # construction
+    np.random.seed(SEED)
     sensitive_attr = random.random_integers(0, 1, n_all)
     latent = random.normal(sensitive_attr, latent_std)
     features = random.normal(latent, features_std)

--- a/datasets/sensitive_zhang.py
+++ b/datasets/sensitive_zhang.py
@@ -5,14 +5,14 @@ import tensorflow as tf
 from .definition import Dataset, select_training_and_test, to_tf_dataset_fn
 
 
-def sensitive_zhang():
+def sensitive_zhang(flags):
     """
     Toy dataset from Zhang (2017) 'Mitigating Unwanted Biases with Adversarial Learning'
     """
     # parameters
     n_all = 1000
     num_train = 750
-    num_inducing = 250
+    num_inducing = flags['num_inducing']  # 250
     latent_std = 2.  # standard dev of the latent variable that we're trying to predict. bigger -> easier to predict
     features_std = .5  # standard dev of the features with respect to latent var. smaller -> easier to predict
     raw_output_std = .5  # standard dev of the raw output with respect to latent var. smaller -> easier to predict

--- a/datasets/sensitive_zhang.py
+++ b/datasets/sensitive_zhang.py
@@ -24,7 +24,7 @@ def sensitive_zhang():
     raw_output = random.normal(latent, raw_output_std)
     labels = (raw_output > 0).astype(np.int)
 
-    xtrain, ytrain, xtest, ytest, strain, stest = select_training_and_test(
+    (xtrain, ytrain, strain), (xtest, ytest, stest) = select_training_and_test(
         num_train, features[..., np.newaxis], labels[..., np.newaxis], sensitive_attr[..., np.newaxis])
 
     return Dataset(

--- a/datasets/simple.py
+++ b/datasets/simple.py
@@ -7,14 +7,15 @@ import numpy as np
 from .definition import Dataset, select_training_and_test, to_tf_dataset_fn
 
 
-def simple_example():
+def simple_example(flags):
     """Simple 1D example with synthetic data."""
     n_all = 200
     num_train = 50
+    num_inducing = flags['num_inducing']
+
     inputs = np.linspace(0, 5, num=n_all)[:, np.newaxis]
     outputs = np.cos(inputs)
     (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
-    num_inducing = 50
 
     return Dataset(train_fn=to_tf_dataset_fn(xtrain, ytrain),
                    test_fn=to_tf_dataset_fn(xtest, ytest),
@@ -30,15 +31,16 @@ def simple_example():
                    ytest=ytest)
 
 
-def simple_multi_out():
+def simple_multi_out(flags):
     """Example with multi-dimensional output."""
     n_all = 200
     num_train = 50
+    num_inducing = flags['num_inducing']
+
     inputs = np.linspace(0, 5, num=n_all)[:, np.newaxis]
     output1 = np.cos(inputs)
     output2 = np.sin(inputs)
     outputs = np.concatenate((output1, output2), axis=1)
-    num_inducing = 50
 
     (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
 
@@ -56,16 +58,17 @@ def simple_multi_out():
                    ytest=ytest)
 
 
-def simple_multi_in():
+def simple_multi_in(flags):
     """Example with multi-dimensional input."""
     n_all = 200
     num_train = 50
+    num_inducing = flags['num_inducing']
+
     input1 = np.linspace(-1, 1, num=n_all)[:, np.newaxis]
     input2 = np.linspace(-1, 1, num=n_all)[:, np.newaxis]
     inputs = np.concatenate((input1, input2), 1)
     # outputs = np.cos(input1 + input2)
     outputs = input1**2 + input2**2
-    num_inducing = 50
 
     (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
 

--- a/datasets/simple.py
+++ b/datasets/simple.py
@@ -13,7 +13,7 @@ def simple_example():
     num_train = 50
     inputs = np.linspace(0, 5, num=n_all)[:, np.newaxis]
     outputs = np.cos(inputs)
-    xtrain, ytrain, xtest, ytest = select_training_and_test(num_train, inputs, outputs)
+    (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
     num_inducing = 50
 
     return Dataset(train_fn=to_tf_dataset_fn(xtrain, ytrain),
@@ -40,7 +40,7 @@ def simple_multi_out():
     outputs = np.concatenate((output1, output2), axis=1)
     num_inducing = 50
 
-    xtrain, ytrain, xtest, ytest = select_training_and_test(num_train, inputs, outputs)
+    (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
 
     return Dataset(train_fn=to_tf_dataset_fn(xtrain, ytrain),
                    test_fn=to_tf_dataset_fn(xtest, ytest),
@@ -67,7 +67,7 @@ def simple_multi_in():
     outputs = input1**2 + input2**2
     num_inducing = 50
 
-    xtrain, ytrain, xtest, ytest = select_training_and_test(num_train, inputs, outputs)
+    (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
 
     return Dataset(train_fn=to_tf_dataset_fn(xtrain, ytrain),
                    test_fn=to_tf_dataset_fn(xtest, ytest),

--- a/datasets/simple.py
+++ b/datasets/simple.py
@@ -1,10 +1,11 @@
 """
 Simple datasets for testing
 """
-
 import numpy as np
 
 from .definition import Dataset, select_training_and_test, to_tf_dataset_fn
+
+SEED = 1234
 
 
 def simple_example(flags):
@@ -15,6 +16,8 @@ def simple_example(flags):
 
     inputs = np.linspace(0, 5, num=n_all)[:, np.newaxis]
     outputs = np.cos(inputs)
+
+    np.random.seed(SEED)
     (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
 
     return Dataset(train_fn=to_tf_dataset_fn(xtrain, ytrain),
@@ -42,6 +45,7 @@ def simple_multi_out(flags):
     output2 = np.sin(inputs)
     outputs = np.concatenate((output1, output2), axis=1)
 
+    np.random.seed(SEED)
     (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
 
     return Dataset(train_fn=to_tf_dataset_fn(xtrain, ytrain),
@@ -70,6 +74,7 @@ def simple_multi_in(flags):
     # outputs = np.cos(input1 + input2)
     outputs = input1**2 + input2**2
 
+    np.random.seed(SEED)
     (xtrain, ytrain), (xtest, ytest) = select_training_and_test(num_train, inputs, outputs)
 
     return Dataset(train_fn=to_tf_dataset_fn(xtrain, ytrain),

--- a/gaussian_process.py
+++ b/gaussian_process.py
@@ -21,6 +21,7 @@ tf.app.flags.DEFINE_string('inf', 'Variational', 'Inference method')
 tf.app.flags.DEFINE_string('cov', 'SquaredExponential', 'Covariance function')
 tf.app.flags.DEFINE_float('lr', 0.005, 'Learning rate')
 tf.app.flags.DEFINE_integer('loo_steps', None, 'Number of steps for optimizing LOO loss')
+tf.app.flags.DEFINE_integer('num_inducing', 50, 'Suggested number of inducing inputs (datasets don\'t have to use it)')
 ### Tensorflow flags
 tf.app.flags.DEFINE_string('model_name', 'local', 'Name of model (used for name of checkpoints)')
 tf.app.flags.DEFINE_integer('batch_size', 50, 'Batch size')
@@ -53,8 +54,8 @@ def main(_):
         tfe.enable_eager_execution()  # enable Eager Execution (tensors are evaluated immediately, no sessions)
     else:
         raise ValueError(f"Unknown tf_mode: \"{FLAGS.tf_mode}\"")
-    dataset = getattr(datasets, FLAGS.data)()  # take dataset function from the module `datasets` and execute it
     args = {flag: getattr(FLAGS, flag) for flag in FLAGS}  # convert FLAGS to dictionary
+    dataset = getattr(datasets, FLAGS.data)(args)  # take dataset function from the module `datasets` and execute it
     train_func.train_gp(dataset, args)
 
 

--- a/scripts/flagfiles/simple_example.sh
+++ b/scripts/flagfiles/simple_example.sh
@@ -13,8 +13,8 @@
 --tf_mode=graph
 
 # No plotting
---plot=
-# --plot=simple_1d
+# --plot=
+--plot=simple_1d
 
 --num_samples=100
 --num_samples_pred=2000


### PR DESCRIPTION
The function `select_training_and_test` can now take an arbitrary number of arguments and will split them all into train and test in the same way. This is for example useful for sensitive attributes.

Flags are passed to the dataset functions. As an example, there is now the flag `num_inducing` where you can specify the number of inducing variables. The datasets don't have to follow that though.

Other changes:

* remove unused import
* put SEED outside the main function
* add `np.random.seed()` in every dataset that uses random numbers